### PR TITLE
Specify the country field

### DIFF
--- a/HoneyCredIPTracker.sh
+++ b/HoneyCredIPTracker.sh
@@ -8,7 +8,7 @@ cat passwds.txt | sort | uniq -c | sort -nr > sortedpasswords.txt
 for IP in `cat sortedips.txt | awk '{print $2}'`
 do
     echo "Checking $IP …"
-    curl -s http://ipinfo.io/$IP | grep country | awk -F'"' '{ print $4 }' >> country.txt
+    curl -s http://ipinfo.io/$IP/country >> country.txt
 
 done
 


### PR DESCRIPTION
It isn't needed to get the full set of details for the IP when we just need the country-code.

Source: http://ipinfo.io/developers/jsonp-requests